### PR TITLE
fixed spotlight page, removed "ignore" page

### DIFF
--- a/Extensions/panaroma.js
+++ b/Extensions/panaroma.js
@@ -30,8 +30,8 @@ XKit.extensions.panaroma = new Object({
 
 		}
 
-		if (document.location.href.indexOf("://www.tumblr.com/ignore") !== -1 ||
-			document.location.href.indexOf("://www.tumblr.com/lookup") !== -1 ||
+		//removed "www.tumblr.com/ignore" references, no longer exists
+		if (document.location.href.indexOf("://www.tumblr.com/lookup") !== -1 ||
 			document.location.href.indexOf("://www.tumblr.com/spotlight") !== -1 ||
 			document.location.href.indexOf("://www.tumblr.com/following") !== -1) {
 			XKit.extensions.panaroma.do_directory_fixes();
@@ -42,13 +42,14 @@ XKit.extensions.panaroma = new Object({
 		XKit.extensions.panaroma.resized();
 	},
 
+	//added fixes for Spotlight a.k.a. "Staff Picks" page and removed obsolete fixes for Ignore page
 	do_directory_fixes: function() {
 
 		var m_css = " .l-content { padding-bottom: 30px!important; border-radius: 20px!important; background: white!important; } .content_top, .content_bottom { display: none!important; } #tabs { background: #eaeaea!important; } #tabs.tabs_3 .tab { width: 33%!important; } #tabs.tabs_3 .tab:last-child { width: 32%!important; } ";
 
-		if (document.location.href.indexOf("://www.tumblr.com/ignore") !== -1) {
-			m_css = m_css + " #left_column { width: 100%!important; } #content { padding-top: 30px!important;  } ";
-		}
+		if (document.location.href.indexOf("://www.tumblr.com/spotlight") !== -1) {
+    			m_css = m_css + " .chrome_nav { width: 24%!important; min-width: 230px!important; } #cards { width: 75%!important; min-width: 650px!important; } #cards .card{ width:30%!important; min-width:190px!important; }#content { padding-top: 30px!important;  } ";
+	    }
 
 		XKit.tools.add_css(m_css, "panaroma_directory");
 


### PR DESCRIPTION
Since Tumblr changed the old "ignore" to the new user blocking, tumblr.com/ignore gives a 404 page. Removed the fixes for that page since they're no longer needed.

Attempted to add special-case fixes for the "Staff Picks" tumblr.com/spotlight page, I'm sure there's room for improvement or optimization; I'm horribly rusty with CSS anymore.
